### PR TITLE
Lots of cleanup

### DIFF
--- a/modules/node/lib/node.dart
+++ b/modules/node/lib/node.dart
@@ -26,7 +26,7 @@ abstract class Node {
   /// Emits events when this node disconnects from a [Peer].
   Stream<Peer> get onDisconnect;
 
-  Future<Null> connect(Peer peer);
+  Future connect(Peer peer);
 
   /// Disconnects from the remote peer identified by [name] and [address].
   void disconnect(Peer peer);
@@ -39,7 +39,7 @@ abstract class Node {
 
   /// Closes all connections and disables the node. Be sure to call [disconnect]
   /// before calling [shutdown] to remove the node from any connected networks.
-  Future<Null> shutdown();
+  Future shutdown();
 
   Peer toPeer() => new Peer(name, address);
 }
@@ -68,7 +68,7 @@ class DelegatingNode implements Node {
   Stream<Peer> get onDisconnect => delegate.onDisconnect;
 
   @override
-  Future<Null> connect(Peer peer) => delegate.connect(peer);
+  Future connect(Peer peer) => delegate.connect(peer);
 
   @override
   void disconnect(Peer peer) {
@@ -84,7 +84,7 @@ class DelegatingNode implements Node {
   Stream<Message> receive(String action) => delegate.receive(action);
 
   @override
-  Future<Null> shutdown() => delegate.shutdown();
+  Future shutdown() => delegate.shutdown();
 
   @override
   Peer toPeer() => delegate.toPeer();

--- a/modules/node/lib/src/connection/connection_strategy.dart
+++ b/modules/node/lib/src/connection/connection_strategy.dart
@@ -2,23 +2,23 @@ import 'dart:async';
 
 import 'package:distributed.node/src/connection/connection.dart';
 import 'package:distributed.node/src/connection/connection_channels.dart';
-import 'package:distributed.node/src/peer_identification_strategy.dart';
-import 'package:distributed.node/src/message/message.dart';
 import 'package:distributed.node/src/node_finder.dart';
 import 'package:distributed.node/src/peer.dart';
+import 'package:distributed.node/src/peer_identification_strategy.dart';
+import 'package:distributed.port_daemon/src/ports.dart';
 
 abstract class ConnectionStrategy<T> {
   Future<Connection<T>> connect(String localPeerName, String remotePeerName);
 }
 
-class RequireIdentification implements ConnectionStrategy<Message> {
-  ConnectionStrategy<Message> _connectionStrategy;
-  PeerIdentificationStrategy _identificationStrategy;
+class RequireIdentification<T> implements ConnectionStrategy<T> {
+  ConnectionStrategy<T> _connectionStrategy;
+  PeerIdentificationStrategy<T> _identificationStrategy;
 
   RequireIdentification(this._connectionStrategy, this._identificationStrategy);
 
   @override
-  Future<Connection<Message>> connect(
+  Future<Connection<T>> connect(
     String localPeerName,
     String remotePeerName,
   ) async {
@@ -53,7 +53,7 @@ class SearchForNode<T> implements ConnectionStrategy<T> {
     }
 
     var remotePeerPort = await _nodeFinder.findNodePort(remotePeerName);
-    if (remotePeerPort == -1) {
+    if (remotePeerPort == Ports.invalidPort.toInt()) {
       throw new Exception('node not found $remotePeerName');
     }
 

--- a/modules/node/lib/src/cross_platform_node.dart
+++ b/modules/node/lib/src/cross_platform_node.dart
@@ -55,7 +55,7 @@ class CrossPlatformNode implements Node {
   Stream<Peer> get onDisconnect => _onDisconnectController.stream;
 
   @override
-  Future<Null> connect(Peer peer) async {
+  Future connect(Peer peer) async {
     assert(!_connections.containsKey(peer));
     _addConnection(await _connectionStrategy.connect(name, peer.name));
   }
@@ -78,7 +78,7 @@ class CrossPlatformNode implements Node {
       .where((Message message) => message.category == action);
 
   @override
-  Future<Null> shutdown() async {
+  Future shutdown() async {
     _onUserMessageController.close();
     _onConnectController.close();
     if (peers.isNotEmpty) {

--- a/modules/node/lib/src/io/io_node.dart
+++ b/modules/node/lib/src/io/io_node.dart
@@ -44,7 +44,7 @@ class IONode extends DelegatingNode {
   }
 
   @override
-  Future<Null> shutdown() async {
+  Future shutdown() async {
     await super.shutdown();
     await _server.close(force: true);
     await _daemonClient.deregisterNode(name);

--- a/modules/node/lib/src/socket/socket_channels.dart
+++ b/modules/node/lib/src/socket/socket_channels.dart
@@ -11,6 +11,7 @@ class SocketChannels implements ConnectionChannels<String> {
   static const _KEY_USR = '0';
   static const _KEY_SYS = '1';
   static const _KEY_ERR = '2';
+  static final _timeoutError = 'Remote $SocketChannels timed out';
 
   @override
   final StreamChannel<String> user;
@@ -36,7 +37,8 @@ class SocketChannels implements ConnectionChannels<String> {
     }));
 
     var timeout = new Timeout(() {
-      throw new TimeoutException('Remote SocketDemultiplexer timeod out');
+      splitter.primaryChannel.sink.close();
+      throw new TimeoutException(_timeoutError);
     });
 
     var message = JSON.decode(await splitter.primaryChannel.stream.first);
@@ -49,7 +51,7 @@ class SocketChannels implements ConnectionChannels<String> {
         socket,
       );
     } else {
-      throw new Exception('SocketDemultiplexer: ${message['error']}');
+      throw new Exception('$SocketChannels: ${message['error']}');
     }
   }
 
@@ -57,7 +59,7 @@ class SocketChannels implements ConnectionChannels<String> {
     var splitter = new SocketSplitter(socket);
     var timeout = new Timeout(() {
       splitter.primaryChannel.sink.close();
-      throw new TimeoutException('Remote SocketDemultiplexer timeod out');
+      throw new TimeoutException(_timeoutError);
     });
 
     var message = JSON.decode(await splitter.primaryChannel.stream.first);

--- a/modules/node/test/connection_strategy_tests.dart
+++ b/modules/node/test/connection_strategy_tests.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:distributed.node/src/connection/connection_strategy.dart';
-import 'package:distributed.node/src/message/message.dart';
 import 'package:distributed.node/src/node_finder.dart';
 import 'package:distributed.node/src/peer.dart';
 import 'package:distributed.node/testing/test_channels_connection.dart';
+import 'package:distributed.port_daemon/src/ports.dart';
 import 'package:test/test.dart';
 
 import 'src/connection_strategy_test.dart' as connection_strategy_test;
@@ -46,8 +46,8 @@ class _TestNodeFinder implements NodeFinder {
       new Future<String>.value(_nodeInfoCache[nodeName]?.address ?? '');
 
   @override
-  Future<int> findNodePort(String nodeName) =>
-      new Future<int>.value(_nodeInfoCache[nodeName]?.port ?? -1);
+  Future<int> findNodePort(String nodeName) => new Future<int>.value(
+      _nodeInfoCache[nodeName]?.port ?? Ports.invalidPort.toInt());
 }
 
 class _NodeInfo {

--- a/modules/node/test/src/node_finder_test.dart
+++ b/modules/node/test/src/node_finder_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:distributed.node/src/node_finder.dart';
 import 'package:distributed.node/src/peer.dart';
+import 'package:distributed.port_daemon/src/ports.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
@@ -38,8 +39,10 @@ void main({
       expect(await finder.findNodePort(peer.name), peerPort);
     });
 
-    test("should return -1 if the node doesn't exist", () async {
-      expect(await finder.findNodePort('unregistered'), -1);
+    test("should return ${Ports.invalidPort} if the node doesn't exist",
+        () async {
+      expect(
+          await finder.findNodePort('unregistered'), Ports.invalidPort.toInt());
     });
   });
 }

--- a/modules/port_daemon/lib/src/api.dart
+++ b/modules/port_daemon/lib/src/api.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:distributed.port_daemon/src/ports.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:meta/meta.dart';
 
@@ -30,7 +31,7 @@ class RegistrationResult extends Message {
 
   RegistrationResult.failure()
       : name = '',
-        port = new Int64(-1),
+        port = Ports.invalidPort,
         _failed = true;
 
   factory RegistrationResult.fromJson(Map<String, Object> json) =>

--- a/modules/port_daemon/lib/src/port_daemon.dart
+++ b/modules/port_daemon/lib/src/port_daemon.dart
@@ -53,7 +53,7 @@ class PortDaemon {
   /// Frees the port held by the node named [name].
   ///
   /// An argument error is thrown if such a node does not exist.
-  Future<Null> deregisterNode(String name) async {
+  Future deregisterNode(String name) async {
     Int64 port;
     if ((port = await lookupPort(name)) < Int64.ZERO) {
       throw new Exception('Unable to deregister unregistered node $name');

--- a/modules/port_daemon/test/database/in_memory_database_test.dart
+++ b/modules/port_daemon/test/database/in_memory_database_test.dart
@@ -25,7 +25,7 @@ void main() {
               new StringSerializer(), new StringSerializer()));
     }
 
-    Future<Null> teardown() async {
+    Future teardown() async {
       testFile.deleteSync();
     }
 

--- a/modules/port_daemon/test/database/src/database_test.dart
+++ b/modules/port_daemon/test/database/src/database_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 typedef Future<Database<String, String>> DatabaseProvider();
 
 /// Common tests for [Database].
-void testDatabase(DatabaseProvider setup, Future<Null> teardown()) {
+void testDatabase(DatabaseProvider setup, Future teardown()) {
   Database<String, String> database;
 
   group('', () {


### PR DESCRIPTION
- close #14: Clean up _SocketSplitter
- close #13: Use Ports.invalidPort.toInt() instead of -1 everywhere
- close #12: Omit <Null> in Futures that return null values
- close #11: Clean up Strings in SocketChannels
- close #10: Close pimaryChannel when timeout occurs in SocketChannel.outgoing
- close #9: Clean up messy typing in ConnectionStrategy